### PR TITLE
Fixup authors for llama kitfiles

### DIFF
--- a/kitfiles/llama2.yml
+++ b/kitfiles/llama2.yml
@@ -4,7 +4,7 @@ package:
   version: 2.0.0
   description: >-
     Llama 2 is a collection of foundation language models ranging from 7B to 70B parameters.
-  authors: [Meta Platforms, Inc.]
+  authors: ["Meta Platforms, Inc."]
 code:
   - path: LICENSE.txt
     description: License file.

--- a/kitfiles/llama3.yml
+++ b/kitfiles/llama3.yml
@@ -5,7 +5,7 @@ package:
   description: >-
    Llama 3 family of large language models (LLMs), a collection of pretrained and
    instruction tuned generative text models in 8 and 70B sizes.
-  authors: [Meta Platforms, Inc.]
+  authors: ["Meta Platforms, Inc."]
 code:
   - path: LICENSE
     description: License file.


### PR DESCRIPTION
Unquoted string in array literal parses as a list separator, i.e.
```yaml
    authors: [Meta Platforms, Inc.]
```
parses to
```yaml
    authors:
      - Meta Platforms
      - Inc.
```