### PR TITLE
Upload blobs to webscale-registry via rclone.

### DIFF
--- a/.github/workflows/convert-to-gguf.yml
+++ b/.github/workflows/convert-to-gguf.yml
@@ -4,145 +4,144 @@ on:
   workflow_dispatch:
     inputs:
       model_repo:
-          description: 'Huggingface repo'
-          type: string
-          required: true
+        description: "Huggingface repo"
+        type: string
+        required: true
       model_name:
-          type: string
-          description: 'Model name'
-          required: true
+        type: string
+        description: "Model name"
+        required: true
       model_parameters:
-          type: string
-          description: 'Model parameter size'
-          required: true
+        type: string
+        description: "Model parameter size"
+        required: true
       model_variant:
-          type: string
-          description: 'Model variant'
-          required: true
+        type: string
+        description: "Model variant"
+        required: true
       model_qnt:
-          type: string
-          description: 'Model quantization'
-          required: true
-          default: 'f16'
+        type: string
+        description: "Model quantization"
+        required: true
+        default: "f16"
       model_description:
-          type: string
-          description: 'Model description'
-          required: true
+        type: string
+        description: "Model description"
+        required: true
       kitfile_template:
-          type: string
-          description: 'Kitfile template'
-          required: true
+        type: string
+        description: "Kitfile template"
+        required: true
       convert_flags:
-          type: string
-          description: 'Conversion flags'
-          required: false
+        type: string
+        description: "Conversion flags"
+        required: false
       runner:
-          type: string
-          description: 'Runner'
-          required: true
-          default: 'model-factory-runner'
+        type: string
+        description: "Runner"
+        required: true
+        default: "model-factory-runner"
 
 jobs:
-    convert-model:
-        runs-on: ${{ inputs.runner }}
-        permissions:
-          contents: read
-          packages: write
+  convert-model:
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+      packages: write
+    env:
+      HF_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
+      HF_HUB_ENABLE_HF_TRANSFER: 1
+      KITOPS_HOME: "${{ runner.home }}/kitops-build/"
+      TARGET_R2_BUCKET_NAME: "prod-blobs"
+    steps:
+      - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+        # This hack frees up approx 25G.
+        # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
+      - name: Free up runner disk space
+        uses: ublue-os/remove-unwanted-software@e3843c85f5f9b73626845de0f5d44fb78ce22e12 # v6
+
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          ./scripts/check-hf-cli
+          ./scripts/check-convert
+      - name: download model
+        run: ./scripts/hf-clone ${{ inputs.model_repo }} ./model
+      - name: check diskspace after download
+        run: |
+          echo "Disk space after base model downloads"
+          df -h
+      - name: convert model to gguf
+        run: |
+          ./llama.cpp/convert-hf-to-gguf.py \
+          ./model \
+          --outfile ./model/${{inputs.model_name}}-${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}}.gguf \
+          --outtype ${{inputs.model_qnt}} \
+          ${{inputs.convert_flags}}
+      - name: generate kitfile
+        run: |
+          ./scripts/update-kitfile "${{inputs.model_name}}-${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}}" \
+          "${{inputs.model_description}}" ./${{inputs.model_name}}-${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}}.gguf \
+          ${{inputs.kitfile_template}} ./model/Kitfile
+          cat ./model/Kitfile
+      - uses: jozu-ai/gh-kit-setup@1960d89a6396444d03ad93abc1a74a4cf14baccd # v1.0.0
+        name: install kit CLI
+      - name: login to kit
+        run: kit login jozu.ml --username "${{secrets.KIT_USER}}" --password "${{secrets.KIT_PASSWORD}}"
+      - name: check diskspace before pack
+        run: |
+          echo "Disk space before packing model"
+          df -h
+      - name: pack modelkit
+        run: |
+          tree ./model
+          kit pack ./model -t jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}} -v
+
+      # Temporary workaround to allow pushing blobs to R2 directly
+      - name: Setup Rclone
+        uses: AnimMouse/setup-rclone@1a535c480a89e3990d2a0015ea21f6fa3eb1fdc4 ## v1.10.1
+        with:
+          rclone_config: ${{ secrets.RCLONE_CONFIG }}
+      - name: copy blobs up to R2 storage
+        run: |
+          # Copy all blobs in storage to r2 bucket
+          for d in $(find "$KITOPS_HOME/storage" -type d -name 'sha256'); do
+            for f in $(find $d -type f); do
+              FILENAME="$(basename $f)"
+              TARGET="${TARGET_R2_BUCKET_NAME}/sha256:$FILENAME"
+              echo "[INFO ] Copying $f to r2_storage:$TARGET"
+              echo "[INFO ] Command: rclone copyto "$f" "r2_storage:$TARGET" -v"
+              rclone copyto "$f" "r2_storage:$TARGET" -v
+              echo "[INFO ] Done copying $f to r2_storage:$TARGET"
+              echo ""
+            done
+          done
+      # End temporary workaround
+      - name: push modelkit
+        run: kit push jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}} -v --log-level=trace --progress=none
+      - name: Install jq tool
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+      - name: Get modelkit digest
         env:
-            HF_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
-            HF_HUB_ENABLE_HF_TRANSFER: 1
-            KITOPS_HOME: "${{ runner.home }}/kitops-build/"
-            TARGET_R2_BUCKET_NAME: "prod-blobs"
-        steps:
-            - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-              with:
-                egress-policy: audit
-
-              # This hack frees up approx 25G.
-              # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
-            - name: Free up runner disk space
-              uses: ublue-os/remove-unwanted-software@e3843c85f5f9b73626845de0f5d44fb78ce22e12 # v6
-
-            - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-              with:
-                fetch-depth: 0
-            - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
-              with:
-                python-version: '3.10'
-            - name: Install dependencies
-              run:  |
-                ./scripts/check-hf-cli
-                ./scripts/check-convert
-            - name: download model
-              run: ./scripts/hf-clone ${{ inputs.model_repo }} ./model
-            - name: check diskspace after download
-              run: |
-                echo "Disk space after base model downloads"
-                df -h
-            - name: convert model to gguf
-              run: |
-                ./llama.cpp/convert-hf-to-gguf.py \
-                ./model \
-                --outfile ./model/${{inputs.model_name}}-${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}}.gguf \
-                --outtype ${{inputs.model_qnt}} \
-                ${{inputs.convert_flags}}
-            - name: generate kitfile
-              run: |
-                  ./scripts/update-kitfile "${{inputs.model_name}}-${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}}" \
-                  "${{inputs.model_description}}" ./${{inputs.model_name}}-${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}}.gguf \
-                  ${{inputs.kitfile_template}} ./model/Kitfile
-                  cat ./model/Kitfile
-            - uses: jozu-ai/gh-kit-setup@1960d89a6396444d03ad93abc1a74a4cf14baccd # v1.0.0
-              name: install kit CLI
-            - name: login to kit
-              run: kit login jozu.ml --username "${{secrets.KIT_USER}}" --password "${{secrets.KIT_PASSWORD}}"
-            - name: check diskspace before pack
-              run: |
-                echo "Disk space before packing model"
-                df -h
-            - name: pack modelkit
-              run: |
-                tree ./model
-                kit pack ./model -t jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}} -v
-
-            # Temporary workaround to allow pushing blobs to R2 directly
-            - name: Setup Rclone
-              uses: AnimMouse/setup-rclone@1a535c480a89e3990d2a0015ea21f6fa3eb1fdc4  ## v1.10.1
-              with:
-                rclone_config: ${{ secrets.RCLONE_CONFIG }}
-            - name: copy blobs up to R2 storage
-              run: |
-                # Copy all blobs in storage to r2 bucket
-                for d in $(find "$KITOPS_HOME/storage" -type d -name 'sha256'); do
-                  for f in $(find $d -type f); do
-                    FILENAME="$(basename $f)"
-                    TARGET="${TARGET_R2_BUCKET_NAME}/sha256:$FILENAME"
-                    echo "[INFO ] Copying $f to r2_storage:$TARGET"
-                    echo "[INFO ] Command: rclone copyto "$f" "r2_storage:$TARGET" -v"
-                    rclone copyto "$f" "r2_storage:$TARGET" -v
-                    echo "[INFO ] Done copying $f to r2_storage:$TARGET"
-                    echo ""
-                  done
-                done
-            # End temporary workaround
-
-            - name: push modelkit
-              run: kit push jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}} -v --log-level=trace --progress=none
-            - name: Install jq tool
-              run: |
-                sudo apt-get update
-                sudo apt-get install jq
-            - name: Get modelkit digest
-              env:
-                MODELKIT_REF: jozu.ml/jozu/${{inputs.model_name}}
-                MODELKIT_TAG: ${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}}
-              id: digest
-              run: |
-                  echo "modelkit_sha=$(kit inspect ${MODELKIT_REF}:${MODELKIT_TAG} --remote | jq -r '.digest')" >> $GITHUB_OUTPUT
-            - name: Install cosign
-              uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
-            - name: Sign modelkit
-              env:
-                MODELKIT_REF: jozu.ml/jozu/${{inputs.model_name}}@${{ steps.digest.outputs.modelkit_sha }}
-              run: |
-                cosign sign --yes --registry-username "${{secrets.KIT_USER}}" --registry-password "${{secrets.KIT_PASSWORD}}" $MODELKIT_REF
+          MODELKIT_REF: jozu.ml/jozu/${{inputs.model_name}}
+          MODELKIT_TAG: ${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}}
+        id: digest
+        run: |
+          echo "modelkit_sha=$(kit inspect ${MODELKIT_REF}:${MODELKIT_TAG} --remote | jq -r '.digest')" >> $GITHUB_OUTPUT
+      - name: Install cosign
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+      - name: Sign modelkit
+        env:
+          MODELKIT_REF: jozu.ml/jozu/${{inputs.model_name}}@${{ steps.digest.outputs.modelkit_sha }}
+        run: |
+          cosign sign --yes --registry-username "${{secrets.KIT_USER}}" --registry-password "${{secrets.KIT_PASSWORD}}" $MODELKIT_REF

--- a/.github/workflows/convert-to-gguf.yml
+++ b/.github/workflows/convert-to-gguf.yml
@@ -36,7 +36,7 @@ on:
           type: string
           description: 'Conversion flags'
           required: false
-      runner: 
+      runner:
           type: string
           description: 'Runner'
           required: true
@@ -51,11 +51,13 @@ jobs:
         env:
             HF_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
             HF_HUB_ENABLE_HF_TRANSFER: 1
+            KITOPS_HOME: "${{ runner.home }}/kitops-build/"
+            TARGET_R2_BUCKET_NAME: "prod-blobs"
         steps:
             - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
               with:
                 egress-policy: audit
-            
+
               # This hack frees up approx 25G.
               # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
             - name: Free up runner disk space
@@ -102,6 +104,28 @@ jobs:
               run: |
                 tree ./model
                 kit pack ./model -t jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}} -v
+
+            # Temporary workaround to allow pushing blobs to R2 directly
+            - name: Setup Rclone
+              uses: AnimMouse/setup-rclone@1a535c480a89e3990d2a0015ea21f6fa3eb1fdc4  ## v1.10.1
+              with:
+                rclone_config: ${{ secrets.RCLONE_CONFIG }}
+            - name: copy blobs up to R2 storage
+              run: |
+                # Copy all blobs in storage to r2 bucket
+                for d in $(find "$KITOPS_HOME/storage" -type d -name 'sha256'); do
+                  for f in $(find $d -type f); do
+                    FILENAME="$(basename $f)"
+                    TARGET="${TARGET_R2_BUCKET_NAME}/sha256:$FILENAME"
+                    echo "[INFO ] Copying $f to r2_storage:$TARGET"
+                    echo "[INFO ] Command: rclone copyto "$f" "r2_storage:$TARGET" -v"
+                    rclone copyto "$f" "r2_storage:$TARGET" -v
+                    echo "[INFO ] Done copying $f to r2_storage:$TARGET"
+                    echo ""
+                  done
+                done
+            # End temporary workaround
+
             - name: push modelkit
               run: kit push jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}} -v --log-level=trace --progress=none
             - name: Install jq tool
@@ -122,4 +146,3 @@ jobs:
                 MODELKIT_REF: jozu.ml/jozu/${{inputs.model_name}}@${{ steps.digest.outputs.modelkit_sha }}
               run: |
                 cosign sign --yes --registry-username "${{secrets.KIT_USER}}" --registry-password "${{secrets.KIT_PASSWORD}}" $MODELKIT_REF
-                

--- a/.github/workflows/hf-to-modelkit.yml
+++ b/.github/workflows/hf-to-modelkit.yml
@@ -35,6 +35,8 @@ jobs:
         env:
             HF_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
             HF_HUB_ENABLE_HF_TRANSFER: 1
+            KITOPS_HOME: "${{ runner.home }}/kitops-build/"
+            TARGET_R2_BUCKET_NAME: "prod-blobs"
         steps:
             - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
               with:
@@ -73,6 +75,28 @@ jobs:
               run: |
                 tree ./model
                 cat ${{inputs.kitfile}} | kit pack ./model -f - -t jozu.ml/jozu/${{inputs.model_name}}:${{inputs.modelkit_tag}} -v
+
+            # Temporary workaround to allow pushing blobs to R2 directly
+            - name: Setup Rclone
+              uses: AnimMouse/setup-rclone@1a535c480a89e3990d2a0015ea21f6fa3eb1fdc4  ## v1.10.1
+              with:
+                rclone_config: ${{ secrets.RCLONE_CONFIG }}
+            - name: copy blobs up to R2 storage
+              run: |
+                # Copy all blobs in storage to r2 bucket
+                for d in $(find "$KITOPS_HOME/storage" -type d -name 'sha256'); do
+                  for f in $(find $d -type f); do
+                    FILENAME="$(basename $f)"
+                    TARGET="${TARGET_R2_BUCKET_NAME}/sha256:$FILENAME"
+                    echo "[INFO ] Copying $f to r2_storage:$TARGET"
+                    echo "[INFO ] Command: rclone copyto "$f" "r2_storage:$TARGET" -v"
+                    rclone copyto "$f" "r2_storage:$TARGET" -v
+                    echo "[INFO ] Done copying $f to r2_storage:$TARGET"
+                    echo ""
+                  done
+                done
+            # End temporary workaround
+
             - name: push modelkit
               run: kit push jozu.ml/jozu/${{inputs.model_name}}:${{inputs.modelkit_tag}} -v --log-level=trace --progress=none
             - name: Install jq tool

--- a/.github/workflows/hf-to-modelkit.yml
+++ b/.github/workflows/hf-to-modelkit.yml
@@ -4,117 +4,115 @@ on:
   workflow_dispatch:
     inputs:
       model_repo:
-          description: 'Huggingface repo'
-          type: string
-          required: true
+        description: "Huggingface repo"
+        type: string
+        required: true
       model_name:
-          type: string
-          description: 'Model name'
-          required: true
+        type: string
+        description: "Model name"
+        required: true
       modelkit_tag:
-          type: string
-          description: 'ModelKit tag'
-          required: true
+        type: string
+        description: "ModelKit tag"
+        required: true
       kitfile:
-          type: string
-          description: 'Kitfile'
-          required: true
-      runner: 
-          type: string
-          description: 'Runner'
-          required: true
-          default: 'model-factory-runner'
+        type: string
+        description: "Kitfile"
+        required: true
+      runner:
+        type: string
+        description: "Runner"
+        required: true
+        default: "model-factory-runner"
 
 jobs:
-    convert-model:
-        runs-on: ${{ inputs.runner }}
-        permissions:
-          contents: read
-          packages: write
-          id-token: write
+  convert-model:
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    env:
+      HF_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
+      HF_HUB_ENABLE_HF_TRANSFER: 1
+      KITOPS_HOME: "${{ runner.home }}/kitops-build/"
+      TARGET_R2_BUCKET_NAME: "prod-blobs"
+    steps:
+      - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+        # This hack frees up approx 25G.
+        # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
+      - name: Free up runner disk space
+        uses: ublue-os/remove-unwanted-software@e3843c85f5f9b73626845de0f5d44fb78ce22e12 # v6
+
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          ./scripts/check-hf-cli
+      - name: download model
+        run: ./scripts/hf-clone ${{ inputs.model_repo }} ./model
+      - name: check diskspace after download
+        run: |
+          echo "Disk space after base model downloads"
+          df -h
+
+      - uses: jozu-ai/gh-kit-setup@1960d89a6396444d03ad93abc1a74a4cf14baccd # v1.0.0
+        name: install kit CLI
+      - name: login to kit
+        run: kit login jozu.ml --username "${{secrets.KIT_USER}}" --password "${{secrets.KIT_PASSWORD}}"
+      - name: check diskspace before pack
+        run: |
+          echo "Disk space before packing model"
+          df -h
+      - name: pack modelkit
+        run: |
+          tree ./model
+          cat ${{inputs.kitfile}} | kit pack ./model -f - -t jozu.ml/jozu/${{inputs.model_name}}:${{inputs.modelkit_tag}} -v
+
+      # Temporary workaround to allow pushing blobs to R2 directly
+      - name: Setup Rclone
+        uses: AnimMouse/setup-rclone@1a535c480a89e3990d2a0015ea21f6fa3eb1fdc4 ## v1.10.1
+        with:
+          rclone_config: ${{ secrets.RCLONE_CONFIG }}
+      - name: copy blobs up to R2 storage
+        run: |
+          # Copy all blobs in storage to r2 bucket
+          for d in $(find "$KITOPS_HOME/storage" -type d -name 'sha256'); do
+            for f in $(find $d -type f); do
+              FILENAME="$(basename $f)"
+              TARGET="${TARGET_R2_BUCKET_NAME}/sha256:$FILENAME"
+              echo "[INFO ] Copying $f to r2_storage:$TARGET"
+              echo "[INFO ] Command: rclone copyto "$f" "r2_storage:$TARGET" -v"
+              rclone copyto "$f" "r2_storage:$TARGET" -v
+              echo "[INFO ] Done copying $f to r2_storage:$TARGET"
+              echo ""
+            done
+          done
+      # End temporary workaround
+      - name: push modelkit
+        run: kit push jozu.ml/jozu/${{inputs.model_name}}:${{inputs.modelkit_tag}} -v --log-level=trace --progress=none
+      - name: Install jq tool
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+      - name: Get modelkit digest
         env:
-            HF_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
-            HF_HUB_ENABLE_HF_TRANSFER: 1
-            KITOPS_HOME: "${{ runner.home }}/kitops-build/"
-            TARGET_R2_BUCKET_NAME: "prod-blobs"
-        steps:
-            - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-              with:
-                egress-policy: audit
-            
-              # This hack frees up approx 25G.
-              # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
-            - name: Free up runner disk space
-              uses: ublue-os/remove-unwanted-software@e3843c85f5f9b73626845de0f5d44fb78ce22e12 # v6
-
-            - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-              with:
-                fetch-depth: 0
-            - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
-              with:
-                python-version: '3.10'
-            - name: Install dependencies
-              run:  |
-                ./scripts/check-hf-cli
-            - name: download model
-              run: ./scripts/hf-clone ${{ inputs.model_repo }} ./model
-            - name: check diskspace after download
-              run: |
-                echo "Disk space after base model downloads"
-                df -h
-
-            - uses: jozu-ai/gh-kit-setup@1960d89a6396444d03ad93abc1a74a4cf14baccd # v1.0.0
-              name: install kit CLI
-            - name: login to kit
-              run: kit login jozu.ml --username "${{secrets.KIT_USER}}" --password "${{secrets.KIT_PASSWORD}}"
-            - name: check diskspace before pack
-              run: |
-                echo "Disk space before packing model"
-                df -h
-            - name: pack modelkit
-              run: |
-                tree ./model
-                cat ${{inputs.kitfile}} | kit pack ./model -f - -t jozu.ml/jozu/${{inputs.model_name}}:${{inputs.modelkit_tag}} -v
-
-            # Temporary workaround to allow pushing blobs to R2 directly
-            - name: Setup Rclone
-              uses: AnimMouse/setup-rclone@1a535c480a89e3990d2a0015ea21f6fa3eb1fdc4  ## v1.10.1
-              with:
-                rclone_config: ${{ secrets.RCLONE_CONFIG }}
-            - name: copy blobs up to R2 storage
-              run: |
-                # Copy all blobs in storage to r2 bucket
-                for d in $(find "$KITOPS_HOME/storage" -type d -name 'sha256'); do
-                  for f in $(find $d -type f); do
-                    FILENAME="$(basename $f)"
-                    TARGET="${TARGET_R2_BUCKET_NAME}/sha256:$FILENAME"
-                    echo "[INFO ] Copying $f to r2_storage:$TARGET"
-                    echo "[INFO ] Command: rclone copyto "$f" "r2_storage:$TARGET" -v"
-                    rclone copyto "$f" "r2_storage:$TARGET" -v
-                    echo "[INFO ] Done copying $f to r2_storage:$TARGET"
-                    echo ""
-                  done
-                done
-            # End temporary workaround
-
-            - name: push modelkit
-              run: kit push jozu.ml/jozu/${{inputs.model_name}}:${{inputs.modelkit_tag}} -v --log-level=trace --progress=none
-            - name: Install jq tool
-              run: |
-                sudo apt-get update
-                sudo apt-get install jq
-            - name: Get modelkit digest
-              env:
-                MODELKIT_REF: jozu.ml/jozu/${{inputs.model_name}}
-                MODELKIT_TAG: ${{inputs.modelkit_tag}}
-              id: digest
-              run: |
-                  echo "modelkit_sha=$(kit inspect ${MODELKIT_REF}:${MODELKIT_TAG} --remote | jq -r '.digest')" >> $GITHUB_OUTPUT
-            - name: Install cosign
-              uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
-            - name: Sign modelkit
-              env:
-                MODELKIT_REF: jozu.ml/jozu/${{inputs.model_name}}@${{ steps.digest.outputs.modelkit_sha }}
-              run: |
-                cosign sign --yes --registry-username "${{secrets.KIT_USER}}" --registry-password "${{secrets.KIT_PASSWORD}}" $MODELKIT_REF
-                
+          MODELKIT_REF: jozu.ml/jozu/${{inputs.model_name}}
+          MODELKIT_TAG: ${{inputs.modelkit_tag}}
+        id: digest
+        run: |
+          echo "modelkit_sha=$(kit inspect ${MODELKIT_REF}:${MODELKIT_TAG} --remote | jq -r '.digest')" >> $GITHUB_OUTPUT
+      - name: Install cosign
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+      - name: Sign modelkit
+        env:
+          MODELKIT_REF: jozu.ml/jozu/${{inputs.model_name}}@${{ steps.digest.outputs.modelkit_sha }}
+        run: |
+          cosign sign --yes --registry-username "${{secrets.KIT_USER}}" --registry-password "${{secrets.KIT_PASSWORD}}" $MODELKIT_REF

--- a/.github/workflows/quantize.yml
+++ b/.github/workflows/quantize.yml
@@ -2,135 +2,134 @@ name: Quantize ModelKit
 
 on:
   workflow_dispatch:
-      inputs:
-          model_name:
-              type: string
-              description: 'Model name'
-              required: true
-          model_variant:
-              type: string
-              description: 'Model variant'
-              required: true
-          model_parameters:
-              type: string
-              description: 'Model parameter size'
-              required: true
-          model_src_qnt:
-              type: string
-              description: 'Model quantization'
-              required: true
-              default: 'f16'
-          model_target_qnt:
-                type: string
-                description: 'Model quantization'
-                required: true
-                default: 'f16'
-          model_description:
-              type: string
-              description: 'Model description'
-              required: true
-          kitfile_template:
-              type: string
-              description: 'Kitfile template'
-              required: true
-          runner: 
-              type: string
-              description: 'Runner'
-              required: true
-              default: 'model-factory-runner'
+    inputs:
+      model_name:
+        type: string
+        description: "Model name"
+        required: true
+      model_variant:
+        type: string
+        description: "Model variant"
+        required: true
+      model_parameters:
+        type: string
+        description: "Model parameter size"
+        required: true
+      model_src_qnt:
+        type: string
+        description: "Model quantization"
+        required: true
+        default: "f16"
+      model_target_qnt:
+        type: string
+        description: "Model quantization"
+        required: true
+        default: "f16"
+      model_description:
+        type: string
+        description: "Model description"
+        required: true
+      kitfile_template:
+        type: string
+        description: "Kitfile template"
+        required: true
+      runner:
+        type: string
+        description: "Runner"
+        required: true
+        default: "model-factory-runner"
 
 jobs:
-    quantize-model:
-        runs-on: ${{ inputs.runner }}
-        permissions:
-          contents: read
-          packages: write
+  quantize-model:
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+      packages: write
+    env:
+      KITOPS_HOME: "${{ runner.home }}/kitops-build/"
+      TARGET_R2_BUCKET_NAME: "prod-blobs"
+    strategy:
+      matrix:
+        qnt: ${{ fromJSON(inputs.model_target_qnt) }}
+    steps:
+      - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+        # This hack frees up approx 25G.
+        # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
+      - name: Free up runner disk space
+        uses: ublue-os/remove-unwanted-software@e3843c85f5f9b73626845de0f5d44fb78ce22e12 # v6
+
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: "3.10"
+      - name: Install quantize dependencies
+        run: ./scripts/check-quantize
+      - uses: jozu-ai/gh-kit-setup@1960d89a6396444d03ad93abc1a74a4cf14baccd # v1.0.0
+        name: install kit CLI
+      - name: login to kit
+        run: kit login jozu.ml --username "${{secrets.KIT_USER}}" --password "${{secrets.KIT_PASSWORD}}"
+      - name: unpack base-modelkit
+        run: |
+          mkdir ./model
+          kit pull jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_src_qnt}}
+          kit unpack jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_src_qnt}} -d ./model
+      - name: quantize model
+        run: |
+          MODEL_PATH=$(yq eval '.model.path' ./model/Kitfile)
+          ./scripts/llama-quantize ./model/$MODEL_PATH \
+          ./model/${{inputs.model_name}}-${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}}.gguf ${{matrix.qnt}}
+      - name: generate kitfile
+        run: |
+          ./scripts/update-kitfile "${{inputs.model_name}}-${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}}" \
+          "${{inputs.model_description}}" ./${{inputs.model_name}}-${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}}.gguf \
+          ${{inputs.kitfile_template}} ./model/Kitfile
+          cat ./model/Kitfile
+      - name: pack modelkit
+        run: |
+          kit pack ./model -t jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}} -v
+
+      # Temporary workaround to allow pushing blobs to R2 directly
+      - name: Setup Rclone
+        uses: AnimMouse/setup-rclone@1a535c480a89e3990d2a0015ea21f6fa3eb1fdc4 ## v1.10.1
+        with:
+          rclone_config: ${{ secrets.RCLONE_CONFIG }}
+      - name: copy blobs up to R2 storage
+        run: |
+          # Copy all blobs in storage to r2 bucket
+          for d in $(find "$KITOPS_HOME/storage" -type d -name 'sha256'); do
+            for f in $(find $d -type f); do
+              FILENAME="$(basename $f)"
+              TARGET="${TARGET_R2_BUCKET_NAME}/sha256:$FILENAME"
+              echo "[INFO ] Copying $f to r2_storage:$TARGET"
+              echo "[INFO ] Command: rclone copyto "$f" "r2_storage:$TARGET" -v"
+              rclone copyto "$f" "r2_storage:$TARGET" -v
+              echo "[INFO ] Done copying $f to r2_storage:$TARGET"
+              echo ""
+            done
+          done
+      # End temporary workaround
+      - name: push modelkit
+        run: kit push jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}} -v --log-level=trace --progress=none
+      - name: Install jq tool
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+      - name: Get modelkit digest
         env:
-            KITOPS_HOME: "${{ runner.home }}/kitops-build/"
-            TARGET_R2_BUCKET_NAME: "prod-blobs"
-        strategy:
-            matrix:
-                qnt: ${{ fromJSON(inputs.model_target_qnt) }}
-        steps:
-            - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-              with:
-                egress-policy: audit
-              
-              # This hack frees up approx 25G.
-              # See the following issue for more info: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
-            - name: Free up runner disk space
-              uses: ublue-os/remove-unwanted-software@e3843c85f5f9b73626845de0f5d44fb78ce22e12 # v6
-            
-            - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-              with:
-                fetch-depth: 0
-            - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
-              with:
-                python-version: '3.10'
-            - name: Install quantize dependencies
-              run: ./scripts/check-quantize
-            - uses: jozu-ai/gh-kit-setup@1960d89a6396444d03ad93abc1a74a4cf14baccd # v1.0.0
-              name: install kit CLI
-            - name: login to kit
-              run: kit login jozu.ml --username "${{secrets.KIT_USER}}" --password "${{secrets.KIT_PASSWORD}}"
-            - name: unpack base-modelkit
-              run: |
-                mkdir ./model
-                kit pull jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_src_qnt}}
-                kit unpack jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_src_qnt}} -d ./model
-            - name: quantize model
-              run: |
-                MODEL_PATH=$(yq eval '.model.path' ./model/Kitfile)
-                ./scripts/llama-quantize ./model/$MODEL_PATH \
-                ./model/${{inputs.model_name}}-${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}}.gguf ${{matrix.qnt}}
-            - name: generate kitfile
-              run: |
-                ./scripts/update-kitfile "${{inputs.model_name}}-${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}}" \
-                "${{inputs.model_description}}" ./${{inputs.model_name}}-${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}}.gguf \
-                ${{inputs.kitfile_template}} ./model/Kitfile
-                cat ./model/Kitfile
-            - name: pack modelkit
-              run: |
-                kit pack ./model -t jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}} -v
-
-            # Temporary workaround to allow pushing blobs to R2 directly
-            - name: Setup Rclone
-              uses: AnimMouse/setup-rclone@1a535c480a89e3990d2a0015ea21f6fa3eb1fdc4  ## v1.10.1
-              with:
-                rclone_config: ${{ secrets.RCLONE_CONFIG }}
-            - name: copy blobs up to R2 storage
-              run: |
-                # Copy all blobs in storage to r2 bucket
-                for d in $(find "$KITOPS_HOME/storage" -type d -name 'sha256'); do
-                  for f in $(find $d -type f); do
-                    FILENAME="$(basename $f)"
-                    TARGET="${TARGET_R2_BUCKET_NAME}/sha256:$FILENAME"
-                    echo "[INFO ] Copying $f to r2_storage:$TARGET"
-                    echo "[INFO ] Command: rclone copyto "$f" "r2_storage:$TARGET" -v"
-                    rclone copyto "$f" "r2_storage:$TARGET" -v
-                    echo "[INFO ] Done copying $f to r2_storage:$TARGET"
-                    echo ""
-                  done
-                done
-            # End temporary workaround
-
-            - name: push modelkit
-              run: kit push jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}} -v --log-level=trace --progress=none
-            - name: Install jq tool
-              run: |
-                sudo apt-get update
-                sudo apt-get install jq
-            - name: Get modelkit digest
-              env:
-                MODELKIT_REF: jozu.ml/jozu/${{inputs.model_name}}
-                MODELKIT_TAG: ${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}}
-              id: digest
-              run: |
-                  echo "modelkit_sha=$(kit inspect ${MODELKIT_REF}:${MODELKIT_TAG} --remote | jq -r '.digest')" >> $GITHUB_OUTPUT
-            - name: Install cosign
-              uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
-            - name: Sign modelkit
-              env:
-                MODELKIT_REF: jozu.ml/jozu/${{inputs.model_name}}@${{ steps.digest.outputs.modelkit_sha }}
-              run: |
-                cosign sign --yes --registry-username "${{secrets.KIT_USER}}" --registry-password "${{secrets.KIT_PASSWORD}}" $MODELKIT_REF
+          MODELKIT_REF: jozu.ml/jozu/${{inputs.model_name}}
+          MODELKIT_TAG: ${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}}
+        id: digest
+        run: |
+          echo "modelkit_sha=$(kit inspect ${MODELKIT_REF}:${MODELKIT_TAG} --remote | jq -r '.digest')" >> $GITHUB_OUTPUT
+      - name: Install cosign
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+      - name: Sign modelkit
+        env:
+          MODELKIT_REF: jozu.ml/jozu/${{inputs.model_name}}@${{ steps.digest.outputs.modelkit_sha }}
+        run: |
+          cosign sign --yes --registry-username "${{secrets.KIT_USER}}" --registry-password "${{secrets.KIT_PASSWORD}}" $MODELKIT_REF

--- a/.github/workflows/quantize.yml
+++ b/.github/workflows/quantize.yml
@@ -45,6 +45,9 @@ jobs:
         permissions:
           contents: read
           packages: write
+        env:
+            KITOPS_HOME: "${{ runner.home }}/kitops-build/"
+            TARGET_R2_BUCKET_NAME: "prod-blobs"
         strategy:
             matrix:
                 qnt: ${{ fromJSON(inputs.model_target_qnt) }}
@@ -89,6 +92,28 @@ jobs:
             - name: pack modelkit
               run: |
                 kit pack ./model -t jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}} -v
+
+            # Temporary workaround to allow pushing blobs to R2 directly
+            - name: Setup Rclone
+              uses: AnimMouse/setup-rclone@1a535c480a89e3990d2a0015ea21f6fa3eb1fdc4  ## v1.10.1
+              with:
+                rclone_config: ${{ secrets.RCLONE_CONFIG }}
+            - name: copy blobs up to R2 storage
+              run: |
+                # Copy all blobs in storage to r2 bucket
+                for d in $(find "$KITOPS_HOME/storage" -type d -name 'sha256'); do
+                  for f in $(find $d -type f); do
+                    FILENAME="$(basename $f)"
+                    TARGET="${TARGET_R2_BUCKET_NAME}/sha256:$FILENAME"
+                    echo "[INFO ] Copying $f to r2_storage:$TARGET"
+                    echo "[INFO ] Command: rclone copyto "$f" "r2_storage:$TARGET" -v"
+                    rclone copyto "$f" "r2_storage:$TARGET" -v
+                    echo "[INFO ] Done copying $f to r2_storage:$TARGET"
+                    echo ""
+                  done
+                done
+            # End temporary workaround
+
             - name: push modelkit
               run: kit push jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}} -v --log-level=trace --progress=none
             - name: Install jq tool


### PR DESCRIPTION
Add a step to the pack -> push process to upload all blobs directly to R2 via rclone. Afterwards, the manifest push should only have to push the manifest via OCI APIs.

Note there's a second commit that's just the result of re-formatting the files, since they mixed 4-space and 2-space indentation.

Depends on: https://github.com/jozu-ai/webscale-registry/pull/50
Requires an rclone config in this repo's secrets (named `RCLONE_CONFIG`):
```ini
[r2_storage]
type = s3
provider = Cloudflare
access_key_id = <access-key>
secret_access_key = <secret-key>
region = auto
endpoint = <endpoint-from-token>
bucket_acl = private
chunk_size = 256Mi
list_version = 2
no_check_bucket = true
```