### PR TITLE
Remove rclone for pushing blobs to R2 storage directly

### DIFF
--- a/.github/workflows/convert-to-gguf.yml
+++ b/.github/workflows/convert-to-gguf.yml
@@ -105,27 +105,6 @@ jobs:
         run: |
           tree ./model
           kit pack ./model -t jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}} -v
-
-      # Temporary workaround to allow pushing blobs to R2 directly
-      - name: Setup Rclone
-        uses: AnimMouse/setup-rclone@1a535c480a89e3990d2a0015ea21f6fa3eb1fdc4 ## v1.10.1
-        with:
-          rclone_config: ${{ secrets.RCLONE_CONFIG }}
-      - name: copy blobs up to R2 storage
-        run: |
-          # Copy all blobs in storage to r2 bucket
-          for d in $(find "$KITOPS_HOME/storage" -type d -name 'sha256'); do
-            for f in $(find $d -type f); do
-              FILENAME="$(basename $f)"
-              TARGET="${TARGET_R2_BUCKET_NAME}/sha256:$FILENAME"
-              echo "[INFO ] Copying $f to r2_storage:$TARGET"
-              echo "[INFO ] Command: rclone copyto "$f" "r2_storage:$TARGET" -v"
-              rclone copyto "$f" "r2_storage:$TARGET" -v
-              echo "[INFO ] Done copying $f to r2_storage:$TARGET"
-              echo ""
-            done
-          done
-      # End temporary workaround
       - name: push modelkit
         run: kit push jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{inputs.model_qnt}} -v --log-level=trace --progress=none
       - name: Install jq tool

--- a/.github/workflows/hf-to-modelkit.yml
+++ b/.github/workflows/hf-to-modelkit.yml
@@ -75,27 +75,6 @@ jobs:
         run: |
           tree ./model
           cat ${{inputs.kitfile}} | kit pack ./model -f - -t jozu.ml/jozu/${{inputs.model_name}}:${{inputs.modelkit_tag}} -v
-
-      # Temporary workaround to allow pushing blobs to R2 directly
-      - name: Setup Rclone
-        uses: AnimMouse/setup-rclone@1a535c480a89e3990d2a0015ea21f6fa3eb1fdc4 ## v1.10.1
-        with:
-          rclone_config: ${{ secrets.RCLONE_CONFIG }}
-      - name: copy blobs up to R2 storage
-        run: |
-          # Copy all blobs in storage to r2 bucket
-          for d in $(find "$KITOPS_HOME/storage" -type d -name 'sha256'); do
-            for f in $(find $d -type f); do
-              FILENAME="$(basename $f)"
-              TARGET="${TARGET_R2_BUCKET_NAME}/sha256:$FILENAME"
-              echo "[INFO ] Copying $f to r2_storage:$TARGET"
-              echo "[INFO ] Command: rclone copyto "$f" "r2_storage:$TARGET" -v"
-              rclone copyto "$f" "r2_storage:$TARGET" -v
-              echo "[INFO ] Done copying $f to r2_storage:$TARGET"
-              echo ""
-            done
-          done
-      # End temporary workaround
       - name: push modelkit
         run: kit push jozu.ml/jozu/${{inputs.model_name}}:${{inputs.modelkit_tag}} -v --log-level=trace --progress=none
       - name: Install jq tool

--- a/.github/workflows/quantize.yml
+++ b/.github/workflows/quantize.yml
@@ -93,27 +93,6 @@ jobs:
       - name: pack modelkit
         run: |
           kit pack ./model -t jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}} -v
-
-      # Temporary workaround to allow pushing blobs to R2 directly
-      - name: Setup Rclone
-        uses: AnimMouse/setup-rclone@1a535c480a89e3990d2a0015ea21f6fa3eb1fdc4 ## v1.10.1
-        with:
-          rclone_config: ${{ secrets.RCLONE_CONFIG }}
-      - name: copy blobs up to R2 storage
-        run: |
-          # Copy all blobs in storage to r2 bucket
-          for d in $(find "$KITOPS_HOME/storage" -type d -name 'sha256'); do
-            for f in $(find $d -type f); do
-              FILENAME="$(basename $f)"
-              TARGET="${TARGET_R2_BUCKET_NAME}/sha256:$FILENAME"
-              echo "[INFO ] Copying $f to r2_storage:$TARGET"
-              echo "[INFO ] Command: rclone copyto "$f" "r2_storage:$TARGET" -v"
-              rclone copyto "$f" "r2_storage:$TARGET" -v
-              echo "[INFO ] Done copying $f to r2_storage:$TARGET"
-              echo ""
-            done
-          done
-      # End temporary workaround
       - name: push modelkit
         run: kit push jozu.ml/jozu/${{inputs.model_name}}:${{inputs.model_parameters}}-${{inputs.model_variant}}-${{matrix.qnt}} -v --log-level=trace --progress=none
       - name: Install jq tool


### PR DESCRIPTION
Remove the temporary workaround of using rclone to sync blobs to R2 directly, and instead use kit push to upload modelkits.

See also: https://github.com/jozu-ai/webscale-registry/pull/66